### PR TITLE
ログインユーザー所得処理を追加

### DIFF
--- a/project/bodquest_2023/lib/application/usecase/add_weight_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/add_weight_usecase_impl.dart
@@ -13,6 +13,6 @@ class AddWeightUsecaseImpl implements IAddWeightUsecase {
     String userId,
     double value,
   ) {
-    return weightRepository.addUser(userId, value);
+    return weightRepository.addWeight(userId, value);
   }
 }

--- a/project/bodquest_2023/lib/application/usecase/get_login_user_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/get_login_user_usecase_impl.dart
@@ -1,0 +1,16 @@
+import '../../domain/entity/user.dart';
+import '../../domain/repository/user_repository.dart';
+import '../../domain/usecase/get_login_user_usecase.dart';
+
+class GetLogInUserUsecaseImpl implements IGetLogInUserUsecase {
+  final IUserRepository _userRepository;
+
+  GetLogInUserUsecaseImpl({
+    required IUserRepository userRepository,
+  }) : _userRepository = userRepository;
+
+  @override
+  Future<User> execute() async {
+    return await _userRepository.getLogInUser();
+  }
+}

--- a/project/bodquest_2023/lib/application/usecase/get_weights_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/get_weights_usecase_impl.dart
@@ -10,7 +10,7 @@ class GetWeightsUsecaseImpl implements IGetWeightsUsecase {
   }) : weightRepository = repository;
 
   @override
-  Stream<List<Weight>> execute() {
-    return weightRepository.findAll();
+  Stream<List<Weight>> execute(String userId) {
+    return weightRepository.findAll(userId);
   }
 }

--- a/project/bodquest_2023/lib/domain/repository/user_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/user_repository.dart
@@ -1,3 +1,4 @@
+import 'package:bodquest_2023/infrastructure/datasource/firebase_auth_user_datasource.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../infrastructure/datasource/firestore_users_datasource.dart';
@@ -7,7 +8,8 @@ import '../factory/user_factory.dart';
 
 final userRepositoryProvider = Provider<IUserRepository>(
   (ref) => UserRepositoryImpl(
-    dataSource: ref.watch(fireStoreUsersDataSourceProvider),
+    fireStoreDataSource: ref.watch(fireStoreUsersDataSourceProvider),
+    firebaseDataSource: ref.watch(firebaseAuthUserDataSourceProvider),
     factory: ref.watch(userFactoryProvider),
   ),
 );
@@ -15,4 +17,5 @@ final userRepositoryProvider = Provider<IUserRepository>(
 abstract interface class IUserRepository {
   /// ユーザー一覧の取得
   Future<List<User>> findAll();
+  Future<User> getLogInUser();
 }

--- a/project/bodquest_2023/lib/domain/repository/weight_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/weight_repository.dart
@@ -14,7 +14,7 @@ final weightRepositoryProvider = Provider<IWeightRepository>(
 
 abstract interface class IWeightRepository {
   /// ユーザー一覧の取得
-  Stream<List<Weight>> findAll();
+  Stream<List<Weight>> findAll(String userId);
   Future<int> addWeight(
     String userId,
     double value,

--- a/project/bodquest_2023/lib/domain/repository/weight_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/weight_repository.dart
@@ -15,7 +15,7 @@ final weightRepositoryProvider = Provider<IWeightRepository>(
 abstract interface class IWeightRepository {
   /// ユーザー一覧の取得
   Stream<List<Weight>> findAll();
-  Future<int> addUser(
+  Future<int> addWeight(
     String userId,
     double value,
   );

--- a/project/bodquest_2023/lib/domain/usecase/get_login_user_usecase.dart
+++ b/project/bodquest_2023/lib/domain/usecase/get_login_user_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/usecase/get_login_user_usecase_impl.dart';
+import '../entity/user.dart';
+import '../repository/user_repository.dart';
+
+final getLogInUserUsecaseProvider = Provider<IGetLogInUserUsecase>(
+  (ref) => GetLogInUserUsecaseImpl(
+    userRepository: ref.watch(userRepositoryProvider),
+  ),
+);
+
+/// ログインユーザーを取得する
+abstract interface class IGetLogInUserUsecase {
+  Future<User> execute();
+}

--- a/project/bodquest_2023/lib/domain/usecase/get_weights_usecase.dart
+++ b/project/bodquest_2023/lib/domain/usecase/get_weights_usecase.dart
@@ -12,5 +12,5 @@ final getWeightsUsecaseProvider = Provider<IGetWeightsUsecase>(
 
 /// ユーザー一覧を取得する
 abstract interface class IGetWeightsUsecase {
-  Stream<List<Weight>> execute();
+  Stream<List<Weight>> execute(String userId);
 }

--- a/project/bodquest_2023/lib/infrastructure/datasource/firebase_auth_user_datasource.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firebase_auth_user_datasource.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../model/firestore/rug_user_login.dart';
+import 'firebase_auth_user_datasource_impl.dart';
+
+final firebaseAuthUserDataSourceProvider =
+    Provider<IFirebaseAuthUserDataSource>(
+  (ref) => FirebaseAuthUserDataSourceImpl(),
+);
+
+abstract interface class IFirebaseAuthUserDataSource {
+  Future<RugUserLogin> getLoginUser();
+}

--- a/project/bodquest_2023/lib/infrastructure/datasource/firebase_auth_user_datasource_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firebase_auth_user_datasource_impl.dart
@@ -1,0 +1,18 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../model/firestore/rug_user_login.dart';
+import 'firebase_auth_user_datasource.dart';
+
+class FirebaseAuthUserDataSourceImpl implements IFirebaseAuthUserDataSource {
+  @override
+  Future<RugUserLogin> getLoginUser() {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    final uid = currentUser == null
+        ? 'tYWPnnG8N0eFGREBP6Io4N5q1Cx2'
+        : currentUser.uid.toString();
+
+    final userName =
+        currentUser == null ? 'no login user' : currentUser.displayName!;
+    return Future.value(RugUserLogin(uuid: uid, username: userName));
+  }
+}

--- a/project/bodquest_2023/lib/infrastructure/datasource/firestore_users_datasource_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firestore_users_datasource_impl.dart
@@ -7,10 +7,9 @@ import 'firestore_users_datasource.dart';
 class FirestoreUsersDataSourceImpl implements IFirestoreUsersDataSource {
   @override
   Future<RugGetUsersResponse> getUsers({int results = 10}) async {
-    const userId = 'srkhd.2023@gmail.com';
     final usersRef = FirebaseFirestore.instance
         .collection('users') // コレクションID
-        .doc(userId);
+        .doc();
 
     RugGetUsersResponse result = RugGetUsersResponse(results: []);
     usersRef.get().then((docSnapshot) => {

--- a/project/bodquest_2023/lib/infrastructure/datasource/firestore_weights_datasource.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firestore_weights_datasource.dart
@@ -9,6 +9,6 @@ final fireStoreWeightsDataSourceProvider =
 );
 
 abstract interface class IFirestoreWeightsDataSource {
-  Stream<RugGetWeightsResponse> getWeights({int results});
+  Stream<RugGetWeightsResponse> getWeights(String userId);
   Future<int> addWeight(String userId, double value);
 }

--- a/project/bodquest_2023/lib/infrastructure/datasource/firestore_weights_datasource_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firestore_weights_datasource_impl.dart
@@ -6,9 +6,7 @@ import 'firestore_weights_datasource.dart';
 
 class FirestoreWeightsDataSourceImpl implements IFirestoreWeightsDataSource {
   @override
-  Stream<RugGetWeightsResponse> getWeights({int results = 10}) {
-    const userId = 'srkhd.2023@gmail.com';
-
+  Stream<RugGetWeightsResponse> getWeights(String userId) {
     return FirebaseFirestore.instance
         .collection('weights')
         .where('userId', isEqualTo: userId)

--- a/project/bodquest_2023/lib/infrastructure/repository/user_repository_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/repository/user_repository_impl.dart
@@ -1,15 +1,21 @@
+import 'package:bodquest_2023/infrastructure/datasource/firebase_auth_user_datasource.dart';
+
 import '../../domain/entity/user.dart';
 import '../../domain/factory/user_factory.dart';
 import '../../domain/repository/user_repository.dart';
+import '../../domain/value/user_gender.dart';
 import '../datasource/firestore_users_datasource.dart';
 
 class UserRepositoryImpl implements IUserRepository {
   UserRepositoryImpl({
-    required IFirestoreUsersDataSource dataSource,
+    required IFirestoreUsersDataSource fireStoreDataSource,
+    required IFirebaseAuthUserDataSource firebaseDataSource,
     required IUserFactory factory,
-  })  : fireStoreDataSource = dataSource,
+  })  : fireStoreDataSource = fireStoreDataSource,
+        firebaseDataSource = firebaseDataSource,
         userFactory = factory;
   final IFirestoreUsersDataSource fireStoreDataSource;
+  final IFirebaseAuthUserDataSource firebaseDataSource;
   final IUserFactory userFactory;
 
   @override
@@ -24,5 +30,15 @@ class UserRepositoryImpl implements IUserRepository {
     } catch (e) {
       rethrow;
     }
+  }
+
+  @override
+  Future<User> getLogInUser() {
+    return firebaseDataSource.getLoginUser().then((value) => Future.value(User(
+        id: value.uuid,
+        name: value.username,
+        gender: UserGender.other,
+        thumbnail: "thumbnail",
+        birthday: DateTime.now())));
   }
 }

--- a/project/bodquest_2023/lib/infrastructure/repository/user_repository_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/repository/user_repository_impl.dart
@@ -8,12 +8,10 @@ import '../datasource/firestore_users_datasource.dart';
 
 class UserRepositoryImpl implements IUserRepository {
   UserRepositoryImpl({
-    required IFirestoreUsersDataSource fireStoreDataSource,
-    required IFirebaseAuthUserDataSource firebaseDataSource,
+    required this.fireStoreDataSource,
+    required this.firebaseDataSource,
     required IUserFactory factory,
-  })  : fireStoreDataSource = fireStoreDataSource,
-        firebaseDataSource = firebaseDataSource,
-        userFactory = factory;
+  }) : userFactory = factory;
   final IFirestoreUsersDataSource fireStoreDataSource;
   final IFirebaseAuthUserDataSource firebaseDataSource;
   final IUserFactory userFactory;

--- a/project/bodquest_2023/lib/infrastructure/repository/weight_repository_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/repository/weight_repository_impl.dart
@@ -13,9 +13,9 @@ class WeightRepositoryImpl implements IWeightRepository {
   final IWeightFactory userFactory;
 
   @override
-  Stream<List<Weight>> findAll() {
+  Stream<List<Weight>> findAll(String userId) {
     try {
-      return fireStoreDataSource.getWeights().map((event) =>
+      return fireStoreDataSource.getWeights(userId).map((event) =>
           [...event.results.map((res) => userFactory.createFromModel(res))]);
     } catch (e) {
       rethrow;

--- a/project/bodquest_2023/lib/infrastructure/repository/weight_repository_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/repository/weight_repository_impl.dart
@@ -23,7 +23,7 @@ class WeightRepositoryImpl implements IWeightRepository {
   }
 
   @override
-  Future<int> addUser(String userId, double value) {
+  Future<int> addWeight(String userId, double value) {
     return fireStoreDataSource.addWeight(userId, value);
   }
 }

--- a/project/bodquest_2023/lib/main.dart
+++ b/project/bodquest_2023/lib/main.dart
@@ -3,11 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'firebase_options.dart';
 
-import 'package:bodquest_2023/presentation/component/main_widget.dart';
-import 'package:bodquest_2023/presentation/component/main_left_drawer.dart';
-import 'package:bodquest_2023/presentation/component/main_bottom_navigation_bar_widget.dart';
-import 'package:bodquest_2023/presentation/component/component_types.dart';
-import 'package:bodquest_2023/presentation/page/login_page.dart';
+import 'presentation/page/myapp_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,65 +13,4 @@ void main() async {
   const app = MaterialApp(home: MyApp());
   const scope = ProviderScope(child: app);
   runApp(scope);
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Bodquest 2023',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: LogInPage(), //const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  TabItem _currentTab = TabItem.home;
-  Map<TabItem, GlobalKey<NavigatorState>> _navigatorKeys = {
-    TabItem.home: GlobalKey<NavigatorState>(),
-    TabItem.setting: GlobalKey<NavigatorState>(),
-    TabItem.view1: GlobalKey<NavigatorState>(),
-    TabItem.view2: GlobalKey<NavigatorState>(),
-    TabItem.sampleCounter: GlobalKey<NavigatorState>(),
-    TabItem.weight: GlobalKey<NavigatorState>(),
-  };
-
-  void _selectTab(TabItem tabItem) {
-    if (tabItem == _currentTab) {
-      _navigatorKeys[tabItem]?.currentState?.popUntil((route) => route.isFirst);
-    } else {
-      setState(() => _currentTab = tabItem);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      drawer: MainLeftDrawer(),
-      body: MainWidget(currentTab: _currentTab, navigatorKeys: _navigatorKeys),
-      bottomNavigationBar: MainBottomNavigationBar(
-        currentTab: _currentTab,
-        onSelect: _selectTab,
-      ),
-    );
-  }
 }

--- a/project/bodquest_2023/lib/presentation/notifier/datetime_notifier.g.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/datetime_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'datetime_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dateTimeNotifierHash() => r'8417080d17dd2b5ad99662164053d099f7b8cdaa';
+String _$dateTimeNotifierHash() => r'1c79514e5a79d9217beb13935757e640f3028567';
 
 /// -----------------------------------------------------------
 /// ノティファイヤー & 自動で作られるプロバイダー - 文字を保存しておく

--- a/project/bodquest_2023/lib/presentation/notifier/login_user_notifier.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/login_user_notifier.dart
@@ -1,0 +1,29 @@
+import 'package:bodquest_2023/presentation/state/loginuser_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/usecase/get_login_user_usecase.dart';
+
+final logInUserNotifierProvider =
+    StateNotifierProvider<LogInUserNotifier, LogInUserState>(
+  (ref) => LogInUserNotifier(
+    getLogInUserUsecase: ref.read(getLogInUserUsecaseProvider),
+  ),
+);
+
+class LogInUserNotifier extends StateNotifier<LogInUserState> {
+  LogInUserNotifier({
+    required IGetLogInUserUsecase getLogInUserUsecase,
+  })  : _getLogInUserUsecase = getLogInUserUsecase,
+        super(LogInUserState(userId: '', userName: '')) {
+    _fetch();
+  }
+
+  final IGetLogInUserUsecase _getLogInUserUsecase;
+
+  /// ログインユーザーの同期
+  Future<void> _fetch() async {
+    final user = await _getLogInUserUsecase.execute();
+    state = LogInUserState(userId: user.id, userName: user.name);
+    //state = _getLogInUserUsecase.execute();
+  }
+}

--- a/project/bodquest_2023/lib/presentation/notifier/weight_list_notifier.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/weight_list_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:bodquest_2023/domain/usecase/add_weight_usecase.dart';
+import 'package:bodquest_2023/domain/usecase/get_login_user_usecase.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/usecase/get_weights_usecase.dart';
@@ -7,27 +8,31 @@ import '../state/weight_state.dart';
 final weightListNotifierProvider =
     StateNotifierProvider<WeightListNotifier, AsyncValue<List<WeightState>>>(
   (ref) => WeightListNotifier(
+    getLogInUserUsecase: ref.read(getLogInUserUsecaseProvider),
     getWeightsUsecase: ref.read(getWeightsUsecaseProvider),
     addWeightUsecase: ref.read(addWeightUsecaseProvider),
   ),
 );
 
 class WeightListNotifier extends StateNotifier<AsyncValue<List<WeightState>>> {
-  WeightListNotifier(
-      {required IGetWeightsUsecase getWeightsUsecase,
-      required IAddWeightUsecase addWeightUsecase})
-      : _getWeightsUsecase = getWeightsUsecase,
+  WeightListNotifier({
+    required IGetLogInUserUsecase getLogInUserUsecase,
+    required IGetWeightsUsecase getWeightsUsecase,
+    required IAddWeightUsecase addWeightUsecase,
+  })  : _getLogInUserUsecase = getLogInUserUsecase,
+        _getWeightsUsecase = getWeightsUsecase,
         _addWeightsUsecase = addWeightUsecase,
         super(const AsyncLoading()) {
-    _fetch();
+    _getLogInUserUsecase.execute().then((value) => _fetch(value.id));
   }
 
+  final IGetLogInUserUsecase _getLogInUserUsecase;
   final IGetWeightsUsecase _getWeightsUsecase;
   final IAddWeightUsecase _addWeightsUsecase;
 
   /// ユーザー一覧の同期
-  Future<void> _fetch() async {
-    _getWeightsUsecase.execute().listen((weights) {
+  Future<void> _fetch(String userId) async {
+    _getWeightsUsecase.execute(userId).listen((weights) {
       state = AsyncValue.data(
           weights.map((weight) => WeightState.fromEntity(weight)).toList());
     });

--- a/project/bodquest_2023/lib/presentation/page/login_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/login_page.dart
@@ -1,11 +1,12 @@
 // ignore_for_file: unused_field
 
 import 'package:bodquest_2023/core/exception/firebasse_auth_exception.dart';
-import 'package:bodquest_2023/main.dart';
 import 'package:bodquest_2023/presentation/page/registration_page.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'myhome_page.dart';
 
 class LogInPage extends StatefulWidget {
   @override

--- a/project/bodquest_2023/lib/presentation/page/myapp_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/myapp_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'login_page.dart';
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Bodquest 2023',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: LogInPage(), //const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/page/myhome_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/myhome_page.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../component/component_types.dart';
+import '../component/main_bottom_navigation_bar_widget.dart';
+import '../component/main_left_drawer.dart';
+import '../component/main_widget.dart';
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  TabItem _currentTab = TabItem.home;
+  Map<TabItem, GlobalKey<NavigatorState>> _navigatorKeys = {
+    TabItem.home: GlobalKey<NavigatorState>(),
+    TabItem.setting: GlobalKey<NavigatorState>(),
+    TabItem.view1: GlobalKey<NavigatorState>(),
+    TabItem.view2: GlobalKey<NavigatorState>(),
+    TabItem.sampleCounter: GlobalKey<NavigatorState>(),
+    TabItem.weight: GlobalKey<NavigatorState>(),
+  };
+
+  void _selectTab(TabItem tabItem) {
+    if (tabItem == _currentTab) {
+      _navigatorKeys[tabItem]?.currentState?.popUntil((route) => route.isFirst);
+    } else {
+      setState(() => _currentTab = tabItem);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      drawer: MainLeftDrawer(),
+      body: MainWidget(currentTab: _currentTab, navigatorKeys: _navigatorKeys),
+      bottomNavigationBar: MainBottomNavigationBar(
+        currentTab: _currentTab,
+        onSelect: _selectTab,
+      ),
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/page/registration_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/registration_page.dart
@@ -1,8 +1,9 @@
 import 'package:bodquest_2023/core/exception/firebasse_auth_exception.dart';
-import 'package:bodquest_2023/main.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'myhome_page.dart';
 
 // アカウント登録ページ
 class RegistrationPage extends StatefulWidget {
@@ -51,7 +52,8 @@ class _RegistrationPageState extends State<RegistrationPage> {
                 decoration: InputDecoration(labelText: "パスワード（8～20文字）"),
                 obscureText: true, // パスワードが見えないようにする
                 maxLength: 20, // 入力可能な文字数
-                maxLengthEnforcement: MaxLengthEnforcement.enforced, // 入力可能な文字数の制限を超える場合の挙動の制御
+                maxLengthEnforcement:
+                    MaxLengthEnforcement.enforced, // 入力可能な文字数の制限を超える場合の挙動の制御
                 onChanged: (String value) {
                   if (value.length >= 8) {
                     _password = value;
@@ -66,14 +68,15 @@ class _RegistrationPageState extends State<RegistrationPage> {
             // 登録失敗時のエラーメッセージ
             Padding(
               padding: EdgeInsets.fromLTRB(20.0, 0, 20.0, 5.0),
-              child: Text(_infoText,style: TextStyle(color: Colors.red)),
+              child: Text(_infoText, style: TextStyle(color: Colors.red)),
             ),
 
             ButtonTheme(
               minWidth: 350.0,
               // height: 100.0,
               child: ElevatedButton(
-                child: Text('登録', style: TextStyle(fontWeight: FontWeight.bold)),
+                child:
+                    Text('登録', style: TextStyle(fontWeight: FontWeight.bold)),
                 onPressed: () async {
                   if (_validPassword) {
                     try {

--- a/project/bodquest_2023/lib/presentation/page/training_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/training_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../component/component_types.dart';
 import '../component/number_textfield_widget.dart';
 import '../component/training_kind_dropdown_widget.dart';
+import '../notifier/login_user_notifier.dart';
 import '../notifier/text_notifier.dart';
 import '../notifier/training_kind_notifier.dart';
 import '../notifier/weight_list_notifier.dart';
@@ -29,7 +30,11 @@ class TrainingPageState extends ConsumerState<TrainingPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(weightListNotifierProvider);
     final kind = ref.watch(trainingKindNotifierProvider);
-    const userId = 'srkhd.2023@gmail.com';
+    final logInUserState = ref.watch(logInUserNotifierProvider);
+
+    print(logInUserState.userId);
+    print(logInUserState.userName);
+    //const userId = 'srkhd.2023@gmail.com';
     final dateState = ref.watch(dateTimeNotifierProvider);
 
     final textField = NumberTextField(

--- a/project/bodquest_2023/lib/presentation/page/training_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/training_page.dart
@@ -34,7 +34,6 @@ class TrainingPageState extends ConsumerState<TrainingPage> {
 
     print(logInUserState.userId);
     print(logInUserState.userName);
-    //const userId = 'srkhd.2023@gmail.com';
     final dateState = ref.watch(dateTimeNotifierProvider);
 
     final textField = NumberTextField(

--- a/project/bodquest_2023/lib/presentation/page/weight_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/weight_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../component/weight_list_item.dart';
+import '../notifier/login_user_notifier.dart';
 import '../notifier/weight_list_notifier.dart';
 
 class WeightPage extends ConsumerStatefulWidget {
@@ -24,7 +25,7 @@ class WeightPageState extends ConsumerState<WeightPage> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(weightListNotifierProvider);
-    const userId = 'srkhd.2023@gmail.com';
+    final logInUserState = ref.watch(logInUserNotifierProvider);
     String inputValue = '0';
 
     return state.when(
@@ -63,7 +64,8 @@ class WeightPageState extends ConsumerState<WeightPage> {
                 onPressed: () {
                   final notifier =
                       ref.read(weightListNotifierProvider.notifier);
-                  notifier.addWeight(userId, double.parse(inputValue));
+                  notifier.addWeight(
+                      logInUserState.userId, double.parse(inputValue));
                   _controller.text = '';
                 },
                 label: Text('登録'),

--- a/project/bodquest_2023/lib/presentation/state/loginuser_state.dart
+++ b/project/bodquest_2023/lib/presentation/state/loginuser_state.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../domain/entity/user.dart';
+
+part 'loginuser_state.freezed.dart';
+
+@freezed
+class LogInUserState with _$LogInUserState {
+  factory LogInUserState({
+    required String userId,
+    required String userName,
+  }) = _LogInUserState;
+
+  factory LogInUserState.fromEntity(User user) {
+    return LogInUserState(
+      userId: user.id,
+      userName: user.name,
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/state/loginuser_state.freezed.dart
+++ b/project/bodquest_2023/lib/presentation/state/loginuser_state.freezed.dart
@@ -1,0 +1,152 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'loginuser_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$LogInUserState {
+  String get userId => throw _privateConstructorUsedError;
+  String get userName => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LogInUserStateCopyWith<LogInUserState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LogInUserStateCopyWith<$Res> {
+  factory $LogInUserStateCopyWith(
+          LogInUserState value, $Res Function(LogInUserState) then) =
+      _$LogInUserStateCopyWithImpl<$Res, LogInUserState>;
+  @useResult
+  $Res call({String userId, String userName});
+}
+
+/// @nodoc
+class _$LogInUserStateCopyWithImpl<$Res, $Val extends LogInUserState>
+    implements $LogInUserStateCopyWith<$Res> {
+  _$LogInUserStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? userName = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      userName: null == userName
+          ? _value.userName
+          : userName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$LogInUserStateImplCopyWith<$Res>
+    implements $LogInUserStateCopyWith<$Res> {
+  factory _$$LogInUserStateImplCopyWith(_$LogInUserStateImpl value,
+          $Res Function(_$LogInUserStateImpl) then) =
+      __$$LogInUserStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String userId, String userName});
+}
+
+/// @nodoc
+class __$$LogInUserStateImplCopyWithImpl<$Res>
+    extends _$LogInUserStateCopyWithImpl<$Res, _$LogInUserStateImpl>
+    implements _$$LogInUserStateImplCopyWith<$Res> {
+  __$$LogInUserStateImplCopyWithImpl(
+      _$LogInUserStateImpl _value, $Res Function(_$LogInUserStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? userName = null,
+  }) {
+    return _then(_$LogInUserStateImpl(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      userName: null == userName
+          ? _value.userName
+          : userName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LogInUserStateImpl implements _LogInUserState {
+  _$LogInUserStateImpl({required this.userId, required this.userName});
+
+  @override
+  final String userId;
+  @override
+  final String userName;
+
+  @override
+  String toString() {
+    return 'LogInUserState(userId: $userId, userName: $userName)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LogInUserStateImpl &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.userName, userName) ||
+                other.userName == userName));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, userId, userName);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LogInUserStateImplCopyWith<_$LogInUserStateImpl> get copyWith =>
+      __$$LogInUserStateImplCopyWithImpl<_$LogInUserStateImpl>(
+          this, _$identity);
+}
+
+abstract class _LogInUserState implements LogInUserState {
+  factory _LogInUserState(
+      {required final String userId,
+      required final String userName}) = _$LogInUserStateImpl;
+
+  @override
+  String get userId;
+  @override
+  String get userName;
+  @override
+  @JsonKey(ignore: true)
+  _$$LogInUserStateImplCopyWith<_$LogInUserStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/project/bodquest_2023/test/widget_test.dart
+++ b/project/bodquest_2023/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:bodquest_2023/presentation/page/myapp_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:bodquest_2023/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
Firebase Authでログインユーザーが取得できれば、その情報からIDやユーザー名を取得できます。
今までメールアドレスをユーザーIDとしていたのをLogInUserのIDを使用するように修正しました。