### PR TITLE
チャートの動作を改善。

### DIFF
--- a/project/bodquest_2023/lib/presentation/page/weight_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/weight_page.dart
@@ -50,7 +50,6 @@ class WeightPageState extends ConsumerState<WeightPage> {
             return formatter.format(dt);
           },
           verticalGridInterval: Duration(days: 1).inMilliseconds.toDouble(),
-          marginTop: 80,
         ),
       );
     }


### PR DESCRIPTION
チャートの動作を改善。

1. x軸ラベルの表示数を制限
2. 表示エリアを拡大