### PR TITLE
献立のモデル対応

### DIFF
--- a/project/bodquest_2023/lib/application/usecase/meal/get_meals_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/meal/get_meals_usecase_impl.dart
@@ -3,14 +3,14 @@ import '../../../domain/repository/meal_repository.dart';
 import '../../../domain/usecase/meal/get_meals_usecase.dart';
 
 class GetMealsUsecaseImpl implements IGetMealsUsecase {
-  final IMealRepository weightRepository;
+  final IMealRepository mealRepository;
 
   GetMealsUsecaseImpl({
     required IMealRepository repository,
-  }) : weightRepository = repository;
+  }) : mealRepository = repository;
 
   @override
   Stream<List<Meal>> execute(String userId) {
-    return weightRepository.findAll(userId);
+    return mealRepository.findAll(userId);
   }
 }

--- a/project/bodquest_2023/lib/application/usecase/menu/add_menu_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/menu/add_menu_usecase_impl.dart
@@ -1,0 +1,24 @@
+import '../../../domain/repository/menu_repository.dart';
+import '../../../domain/usecase/menu/add_menu_usecase.dart';
+
+class AddMenuUsecaseImpl implements IAddMenuUsecase {
+  final IMenuRepository weightRepository;
+
+  AddMenuUsecaseImpl({
+    required IMenuRepository repository,
+  }) : weightRepository = repository;
+
+  @override
+  Future<int> execute(
+    String userId,
+    String name,
+    DateTime date,
+    String recipe,
+    String ingredient,
+    int calorie,
+    String imageFilePath,
+  ) {
+    return weightRepository.addMenu(
+        userId, name, date, recipe, ingredient, calorie, imageFilePath);
+  }
+}

--- a/project/bodquest_2023/lib/application/usecase/menu/get_menus_usecase_impl.dart
+++ b/project/bodquest_2023/lib/application/usecase/menu/get_menus_usecase_impl.dart
@@ -1,0 +1,16 @@
+import '../../../domain/entity/menu.dart';
+import '../../../domain/repository/menu_repository.dart';
+import '../../../domain/usecase/menu/get_menus_usecase.dart';
+
+class GetMenusUsecaseImpl implements IGetMenusUsecase {
+  final IMenuRepository menuRepository;
+
+  GetMenusUsecaseImpl({
+    required IMenuRepository repository,
+  }) : menuRepository = repository;
+
+  @override
+  Stream<List<Menu>> execute(String userId) {
+    return menuRepository.findAll(userId);
+  }
+}

--- a/project/bodquest_2023/lib/domain/entity/menu.dart
+++ b/project/bodquest_2023/lib/domain/entity/menu.dart
@@ -1,0 +1,20 @@
+class Menu {
+  Menu({
+    required this.userId,
+    required this.name,
+    required this.date,
+    required this.timestamp,
+    required this.recipe,
+    required this.ingredient,
+    required this.calorie,
+    required this.imageFilePath,
+  });
+  final String userId; // 識別ID
+  final String name; //名前
+  final DateTime date; // 実施日
+  final int timestamp; // タイムスタンプ
+  final String recipe; // レシピ
+  final String ingredient; // 材料
+  final int calorie; // カロリー
+  final String imageFilePath; //イメージのパス
+}

--- a/project/bodquest_2023/lib/domain/factory/menu/menu_factory.dart
+++ b/project/bodquest_2023/lib/domain/factory/menu/menu_factory.dart
@@ -1,0 +1,19 @@
+import '../../../infrastructure/model/firestore/menu/fug_menu.dart';
+import '../../entity/menu.dart';
+
+abstract interface class IMenuFactory {
+  /// [Menu]を生成する
+  Menu create({
+    required String userId,
+    required String name,
+    required DateTime date,
+    required int timestamp,
+    required String recipe,
+    required String ingredient,
+    required int calorie,
+    required String imageFilePath,
+  });
+
+  /// [FugMenu]から[Menu]を生成する
+  Menu createFromModel(FugMenu meal);
+}

--- a/project/bodquest_2023/lib/domain/repository/meal_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/meal_repository.dart
@@ -1,7 +1,6 @@
 import '../entity/meal.dart';
 
 abstract interface class IMealRepository {
-  /// ユーザー一覧の取得
   Stream<List<Meal>> findAll(String userId);
   Future<int> addMeal(
     String userId,

--- a/project/bodquest_2023/lib/domain/repository/menu_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/menu_repository.dart
@@ -1,0 +1,14 @@
+import '../entity/menu.dart';
+
+abstract interface class IMenuRepository {
+  Stream<List<Menu>> findAll(String userId);
+  Future<int> addMenu(
+    String userId,
+    String name,
+    DateTime date,
+    String recipe,
+    String ingredient,
+    int calorie,
+    String imageFilePath,
+  );
+}

--- a/project/bodquest_2023/lib/domain/repository/training_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/training_repository.dart
@@ -1,7 +1,6 @@
 import '../entity/training.dart';
 
 abstract interface class ITrainingRepository {
-  /// ユーザー一覧の取得
   Stream<List<Training>> findAll(String userId);
   Future<int> addTraining(
     String userId,

--- a/project/bodquest_2023/lib/domain/repository/weight_repository.dart
+++ b/project/bodquest_2023/lib/domain/repository/weight_repository.dart
@@ -1,7 +1,6 @@
 import '../entity/weight.dart';
 
 abstract interface class IWeightRepository {
-  /// ユーザー一覧の取得
   Stream<List<Weight>> findAll(String userId);
   Future<int> addWeight(
     String userId,

--- a/project/bodquest_2023/lib/domain/usecase/meal/add_meal_usecase.dart
+++ b/project/bodquest_2023/lib/domain/usecase/meal/add_meal_usecase.dart
@@ -1,4 +1,3 @@
-/// ユーザー一覧を取得する
 abstract interface class IAddMealUsecase {
   Future<int> execute(
     String userId,

--- a/project/bodquest_2023/lib/domain/usecase/menu/add_menu_usecase.dart
+++ b/project/bodquest_2023/lib/domain/usecase/menu/add_menu_usecase.dart
@@ -1,0 +1,11 @@
+abstract interface class IAddMenuUsecase {
+  Future<int> execute(
+    String userId,
+    String name,
+    DateTime date,
+    String recipe,
+    String ingredient,
+    int calorie,
+    String imageFilePath,
+  );
+}

--- a/project/bodquest_2023/lib/domain/usecase/menu/get_menus_usecase.dart
+++ b/project/bodquest_2023/lib/domain/usecase/menu/get_menus_usecase.dart
@@ -1,0 +1,5 @@
+import '../../entity/menu.dart';
+
+abstract interface class IGetMenusUsecase {
+  Stream<List<Menu>> execute(String userId);
+}

--- a/project/bodquest_2023/lib/infrastructure/datasource/firestore/menus_datasource.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firestore/menus_datasource.dart
@@ -1,0 +1,7 @@
+import '../../model/firestore/menu/fug_get_menus_response.dart';
+
+abstract interface class IFirestoreMenusDataSource {
+  Stream<FugGetMenusResponse> getMenus(String userId);
+  Future<int> addMenu(String userId, String name, DateTime date, String recipe,
+      String ingredient, int calorie, String imageFilePath);
+}

--- a/project/bodquest_2023/lib/infrastructure/datasource/firestore/menus_datasource_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/datasource/firestore/menus_datasource_impl.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../model/firestore/menu/fug_get_menus_response.dart';
+import '../../model/firestore/menu/fug_menu.dart';
+import 'menus_datasource.dart';
+
+class FirestoreMenusDataSourceImpl implements IFirestoreMenusDataSource {
+  @override
+  Stream<FugGetMenusResponse> getMenus(String userId) {
+    return FirebaseFirestore.instance
+        .collection('menus')
+        .where('userId', isEqualTo: userId)
+        .snapshots()
+        .map((value) => FugGetMenusResponse(results: [
+              ...value.docs.map((doc) => FugMenu.fromJson(doc.data()))
+            ]));
+  }
+
+  @override
+  Future<int> addMenu(String userId, String name, DateTime date, String recipe,
+      String ingredient, int calorie, String imageFilePath) async {
+    await FirebaseFirestore.instance
+        .collection('menus') // コレクションID
+        .doc() // ドキュメントID
+        .set({
+      'userId': userId,
+      'name': name,
+      'date': Timestamp.fromDate(date),
+      'recipe': recipe,
+      'ingredient': ingredient,
+      'calorie': calorie,
+      'imageFilePath': imageFilePath,
+    }); // データ
+    return 0;
+  }
+}

--- a/project/bodquest_2023/lib/infrastructure/factory/menu/menu_factory_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/factory/menu/menu_factory_impl.dart
@@ -1,0 +1,59 @@
+import '../../../domain/entity/menu.dart';
+import '../../../domain/factory/menu/menu_factory.dart';
+import '../../datasource/firebase_storage/storage_datasource.dart';
+import '../../model/firestore/menu/fug_menu.dart';
+
+class MenuFactoryImpl implements IMenuFactory {
+  MenuFactoryImpl({required this.firebaseStorageSource});
+
+  final IFirebaseStorageDataSource firebaseStorageSource;
+
+  @override
+  Menu create({
+    required String userId,
+    required String name,
+    required DateTime date,
+    required int timestamp,
+    required String recipe,
+    required String ingredient,
+    required int calorie,
+    required String imageFilePath,
+  }) {
+    return Menu(
+      userId: userId,
+      name: name,
+      timestamp: timestamp,
+      date: date,
+      recipe: recipe,
+      ingredient: ingredient,
+      calorie: calorie,
+      imageFilePath: imageFilePath,
+    );
+  }
+
+  @override
+  Menu createFromModel(FugMenu meal) {
+    // TODO: MenuFactoryImpl createFromModel 非同期で上手く動作するか怪しい
+    firebaseStorageSource.getURL(meal.imageFilePath).then((value) => Menu(
+          userId: meal.userId,
+          name: meal.name,
+          date: meal.date,
+          timestamp: meal.timestamp,
+          recipe: meal.recipe,
+          ingredient: meal.ingredient,
+          calorie: meal.calorie,
+          imageFilePath: value,
+        ));
+
+    return Menu(
+      userId: meal.userId,
+      name: meal.name,
+      date: meal.date,
+      timestamp: meal.timestamp,
+      recipe: meal.recipe,
+      ingredient: meal.ingredient,
+      calorie: meal.calorie,
+      imageFilePath: '',
+    );
+  }
+}

--- a/project/bodquest_2023/lib/infrastructure/model/firestore/meal/fug_get_meals_response.dart
+++ b/project/bodquest_2023/lib/infrastructure/model/firestore/meal/fug_get_meals_response.dart
@@ -8,10 +8,6 @@ class FugGetMealsResponse {
   });
 
   factory FugGetMealsResponse.fromJson(Map<String, dynamic>? json) {
-    return FugGetMealsResponse(results: [FugMeal.fromJson(json)]
-        // results: json?['results']
-        //     .map<FugMeal>((e) => FugMeal.fromJson(e))
-        //     .toList(),
-        );
+    return FugGetMealsResponse(results: [FugMeal.fromJson(json)]);
   }
 }

--- a/project/bodquest_2023/lib/infrastructure/model/firestore/menu/fug_get_menus_response.dart
+++ b/project/bodquest_2023/lib/infrastructure/model/firestore/menu/fug_get_menus_response.dart
@@ -1,0 +1,13 @@
+import 'fug_menu.dart';
+
+class FugGetMenusResponse {
+  final List<FugMenu> results;
+
+  FugGetMenusResponse({
+    required this.results,
+  });
+
+  factory FugGetMenusResponse.fromJson(Map<String, dynamic>? json) {
+    return FugGetMenusResponse(results: [FugMenu.fromJson(json)]);
+  }
+}

--- a/project/bodquest_2023/lib/infrastructure/model/firestore/menu/fug_menu.dart
+++ b/project/bodquest_2023/lib/infrastructure/model/firestore/menu/fug_menu.dart
@@ -1,0 +1,35 @@
+class FugMenu {
+  FugMenu({
+    required this.userId,
+    required this.name,
+    required this.date,
+    required this.timestamp,
+    required this.recipe,
+    required this.ingredient,
+    required this.calorie,
+    required this.imageFilePath,
+  });
+
+  final String userId;
+  final String name;
+  final DateTime date;
+  final int timestamp;
+  final String recipe;
+  final String ingredient;
+  final int calorie;
+  final String imageFilePath;
+
+  factory FugMenu.fromJson(json) {
+    DateTime date = json['date'].toDate();
+    return FugMenu(
+      userId: json['userId'],
+      name: json['name'],
+      date: date,
+      timestamp: date.millisecondsSinceEpoch,
+      recipe: json['recipe'],
+      ingredient: json['ingredient'],
+      calorie: json['calorie'].toInt(),
+      imageFilePath: json['imageFilePath'],
+    );
+  }
+}

--- a/project/bodquest_2023/lib/infrastructure/model/firestore/weight/fug_get_weights_response.dart
+++ b/project/bodquest_2023/lib/infrastructure/model/firestore/weight/fug_get_weights_response.dart
@@ -8,10 +8,6 @@ class FugGetWeightsResponse {
   });
 
   factory FugGetWeightsResponse.fromJson(Map<String, dynamic>? json) {
-    return FugGetWeightsResponse(results: [FugWeight.fromJson(json)]
-        // results: json?['results']
-        //     .map<FugWeight>((e) => FugWeight.fromJson(e))
-        //     .toList(),
-        );
+    return FugGetWeightsResponse(results: [FugWeight.fromJson(json)]);
   }
 }

--- a/project/bodquest_2023/lib/infrastructure/repository/menu_repository_impl.dart
+++ b/project/bodquest_2023/lib/infrastructure/repository/menu_repository_impl.dart
@@ -1,0 +1,40 @@
+import '../../domain/entity/menu.dart';
+import '../../domain/factory/menu/menu_factory.dart';
+import '../../domain/repository/menu_repository.dart';
+import '../datasource/firebase_storage/storage_datasource.dart';
+import '../datasource/firestore/menus_datasource.dart';
+
+class MenuRepositoryImpl implements IMenuRepository {
+  MenuRepositoryImpl({
+    required IFirestoreMenusDataSource dataSource,
+    required IFirebaseStorageDataSource dataStorage,
+    required IMenuFactory factory,
+  })  : fireStoreDataSource = dataSource,
+        firebaseStorageSource = dataStorage,
+        weightFactory = factory;
+  final IFirestoreMenusDataSource fireStoreDataSource;
+  final IFirebaseStorageDataSource firebaseStorageSource;
+  final IMenuFactory weightFactory;
+
+  @override
+  Stream<List<Menu>> findAll(String userId) {
+    try {
+      return fireStoreDataSource.getMenus(userId).map((event) =>
+          [...event.results.map((res) => weightFactory.createFromModel(res))]);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<int> addMenu(String userId, String name, DateTime date, String recipe,
+      String ingredient, int calorie, String imageFilePath) {
+    final storagePath = '${userId}_${name}_image';
+    if (imageFilePath != '') {
+      firebaseStorageSource.addFile(storagePath, imageFilePath);
+    }
+
+    return fireStoreDataSource.addMenu(
+        userId, name, date, recipe, ingredient, calorie, storagePath);
+  }
+}

--- a/project/bodquest_2023/lib/presentation/datasource_module.dart
+++ b/project/bodquest_2023/lib/presentation/datasource_module.dart
@@ -6,6 +6,8 @@ import '../infrastructure/datasource/firebase_storage/storage_datasource.dart';
 import '../infrastructure/datasource/firebase_storage/storage_datasource_impl.dart';
 import '../infrastructure/datasource/firestore/meals_datasource.dart';
 import '../infrastructure/datasource/firestore/meals_datasource_impl.dart';
+import '../infrastructure/datasource/firestore/menus_datasource.dart';
+import '../infrastructure/datasource/firestore/menus_datasource_impl.dart';
 import '../infrastructure/datasource/firestore/trainings_datasource_impl.dart';
 import '../infrastructure/datasource/firestore/users_datasource.dart';
 import '../infrastructure/datasource/firestore/trainings_datasource.dart';
@@ -53,4 +55,11 @@ final fireStoreTrainingsDataSourceProvider =
 ///
 final fireStoreMealsDataSourceProvider = Provider<IFirestoreMealsDataSource>(
   (ref) => FirestoreMealsDataSourceImpl(),
+);
+
+/// Menu
+///
+///
+final fireStoreMenusDataSourceProvider = Provider<IFirestoreMenusDataSource>(
+  (ref) => FirestoreMenusDataSourceImpl(),
 );

--- a/project/bodquest_2023/lib/presentation/factory_provider_module.dart
+++ b/project/bodquest_2023/lib/presentation/factory_provider_module.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../domain/factory/menu/menu_factory.dart';
 import '../infrastructure/factory/meal/meal_factory_impl.dart';
+import '../infrastructure/factory/menu/menu_factory_impl.dart';
 import '../infrastructure/factory/training/training_factory_impl.dart';
 import '../infrastructure/factory/training/training_kind_factory_impl.dart';
 import '../infrastructure/factory/user/user_factory_impl.dart';
@@ -56,6 +58,11 @@ final mealFactoryProvider = Provider<IMealFactory>(
   ),
 );
 
-/// Evaluation
+/// Menu
 ///
 ///
+final menuFactoryProvider = Provider<IMenuFactory>(
+  (ref) => MenuFactoryImpl(
+    firebaseStorageSource: ref.watch(firebaseStorageDataSourceProvider),
+  ),
+);

--- a/project/bodquest_2023/lib/presentation/notifier/meal/meal_list_notifier.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/meal/meal_list_notifier.dart
@@ -23,9 +23,9 @@ class MealListNotifier extends StateNotifier<AsyncValue<List<MealState>>> {
 
   /// 一覧の同期
   Future<void> _fetch(String userId) async {
-    _getMealsUsecase.execute(userId).listen((weights) {
+    _getMealsUsecase.execute(userId).listen((values) {
       state = AsyncValue.data(
-          weights.map((weight) => MealState.fromEntity(weight)).toList());
+          values.map((weight) => MealState.fromEntity(weight)).toList());
     }).onError((e) => print(e));
   }
 

--- a/project/bodquest_2023/lib/presentation/notifier/menu/menu_list_notifier.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/menu/menu_list_notifier.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../domain/usecase/menu/add_menu_usecase.dart';
+import '../../../domain/usecase/menu/get_menus_usecase.dart';
+import '../../../domain/usecase/user/get_login_user_usecase.dart';
+import '../../state/menu/menu_state.dart';
+
+class MenuListNotifier extends StateNotifier<AsyncValue<List<MenuState>>> {
+  MenuListNotifier({
+    required IGetLogInUserUsecase getLogInUserUsecase,
+    required IGetMenusUsecase getMenusUsecase,
+    required IAddMenuUsecase addMenuUsecase,
+  })  : _getLogInUserUsecase = getLogInUserUsecase,
+        _getMenusUsecase = getMenusUsecase,
+        _addMenusUsecase = addMenuUsecase,
+        super(const AsyncLoading()) {
+    _getLogInUserUsecase.execute().then((value) => _fetch(value.id));
+  }
+
+  final IGetLogInUserUsecase _getLogInUserUsecase;
+  final IGetMenusUsecase _getMenusUsecase;
+  final IAddMenuUsecase _addMenusUsecase;
+
+  /// 一覧の同期
+  Future<void> _fetch(String userId) async {
+    _getMenusUsecase.execute(userId).listen((values) {
+      state = AsyncValue.data(
+          values.map((weight) => MenuState.fromEntity(weight)).toList());
+    }).onError((e) => print(e));
+  }
+
+  void addMenu(
+    String userId,
+    String name,
+    DateTime date,
+    String recipe,
+    String ingredient,
+    int calorie,
+    String imageFilePath,
+  ) {
+    _addMenusUsecase.execute(
+        userId, name, date, recipe, ingredient, calorie, imageFilePath);
+  }
+}

--- a/project/bodquest_2023/lib/presentation/notifier/menu/menu_list_provider.dart
+++ b/project/bodquest_2023/lib/presentation/notifier/menu/menu_list_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../state/menu/menu_state.dart';
+import '../../usecaese_provider_module.dart';
+import 'menu_list_notifier.dart';
+
+final menuListNotifierProvider =
+    StateNotifierProvider<MenuListNotifier, AsyncValue<List<MenuState>>>(
+  (ref) => MenuListNotifier(
+    getLogInUserUsecase: ref.read(getLogInUserUsecaseProvider),
+    getMenusUsecase: ref.read(getMenusUsecaseProvider),
+    addMenuUsecase: ref.read(addMenuUsecaseProvider),
+  ),
+);

--- a/project/bodquest_2023/lib/presentation/repository_module.dart
+++ b/project/bodquest_2023/lib/presentation/repository_module.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../domain/repository/menu_repository.dart';
+import '../infrastructure/repository/menu_repository_impl.dart';
 import 'datasource_module.dart';
 import 'factory_provider_module.dart';
 import '../domain/repository/meal_repository.dart';
@@ -49,5 +51,16 @@ final mealRepositoryProvider = Provider<IMealRepository>(
     dataSource: ref.watch(fireStoreMealsDataSourceProvider),
     dataStorage: ref.watch(firebaseStorageDataSourceProvider),
     factory: ref.watch(mealFactoryProvider),
+  ),
+);
+
+/// Menu
+///
+///
+final menuRepositoryProvider = Provider<IMenuRepository>(
+  (ref) => MenuRepositoryImpl(
+    dataSource: ref.watch(fireStoreMenusDataSourceProvider),
+    dataStorage: ref.watch(firebaseStorageDataSourceProvider),
+    factory: ref.watch(menuFactoryProvider),
   ),
 );

--- a/project/bodquest_2023/lib/presentation/state/menu/menu_state.dart
+++ b/project/bodquest_2023/lib/presentation/state/menu/menu_state.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../domain/entity/menu.dart';
+
+part 'menu_state.freezed.dart';
+
+@freezed
+class MenuState with _$MenuState {
+  factory MenuState({
+    required String userId,
+    required String name,
+    required String date,
+    required int timestamp,
+    required String recipe,
+    required String ingredient,
+    required int calorie,
+    required String imageURL,
+  }) = _MenuState;
+
+  factory MenuState.fromEntity(Menu target) {
+    return MenuState(
+      userId: target.userId,
+      name: target.name,
+      date: '${target.date.year}年${target.date.month}月${target.date.day}日',
+      timestamp: target.timestamp,
+      recipe: target.recipe,
+      ingredient: target.ingredient,
+      calorie: target.calorie,
+      imageURL: target.imageFilePath,
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/state/menu/menu_state.freezed.dart
+++ b/project/bodquest_2023/lib/presentation/state/menu/menu_state.freezed.dart
@@ -1,0 +1,279 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'menu_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$MenuState {
+  String get userId => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get date => throw _privateConstructorUsedError;
+  int get timestamp => throw _privateConstructorUsedError;
+  String get recipe => throw _privateConstructorUsedError;
+  String get ingredient => throw _privateConstructorUsedError;
+  int get calorie => throw _privateConstructorUsedError;
+  String get imageURL => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $MenuStateCopyWith<MenuState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MenuStateCopyWith<$Res> {
+  factory $MenuStateCopyWith(MenuState value, $Res Function(MenuState) then) =
+      _$MenuStateCopyWithImpl<$Res, MenuState>;
+  @useResult
+  $Res call(
+      {String userId,
+      String name,
+      String date,
+      int timestamp,
+      String recipe,
+      String ingredient,
+      int calorie,
+      String imageURL});
+}
+
+/// @nodoc
+class _$MenuStateCopyWithImpl<$Res, $Val extends MenuState>
+    implements $MenuStateCopyWith<$Res> {
+  _$MenuStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? name = null,
+    Object? date = null,
+    Object? timestamp = null,
+    Object? recipe = null,
+    Object? ingredient = null,
+    Object? calorie = null,
+    Object? imageURL = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as int,
+      recipe: null == recipe
+          ? _value.recipe
+          : recipe // ignore: cast_nullable_to_non_nullable
+              as String,
+      ingredient: null == ingredient
+          ? _value.ingredient
+          : ingredient // ignore: cast_nullable_to_non_nullable
+              as String,
+      calorie: null == calorie
+          ? _value.calorie
+          : calorie // ignore: cast_nullable_to_non_nullable
+              as int,
+      imageURL: null == imageURL
+          ? _value.imageURL
+          : imageURL // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MenuStateImplCopyWith<$Res>
+    implements $MenuStateCopyWith<$Res> {
+  factory _$$MenuStateImplCopyWith(
+          _$MenuStateImpl value, $Res Function(_$MenuStateImpl) then) =
+      __$$MenuStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String userId,
+      String name,
+      String date,
+      int timestamp,
+      String recipe,
+      String ingredient,
+      int calorie,
+      String imageURL});
+}
+
+/// @nodoc
+class __$$MenuStateImplCopyWithImpl<$Res>
+    extends _$MenuStateCopyWithImpl<$Res, _$MenuStateImpl>
+    implements _$$MenuStateImplCopyWith<$Res> {
+  __$$MenuStateImplCopyWithImpl(
+      _$MenuStateImpl _value, $Res Function(_$MenuStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? name = null,
+    Object? date = null,
+    Object? timestamp = null,
+    Object? recipe = null,
+    Object? ingredient = null,
+    Object? calorie = null,
+    Object? imageURL = null,
+  }) {
+    return _then(_$MenuStateImpl(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String,
+      timestamp: null == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as int,
+      recipe: null == recipe
+          ? _value.recipe
+          : recipe // ignore: cast_nullable_to_non_nullable
+              as String,
+      ingredient: null == ingredient
+          ? _value.ingredient
+          : ingredient // ignore: cast_nullable_to_non_nullable
+              as String,
+      calorie: null == calorie
+          ? _value.calorie
+          : calorie // ignore: cast_nullable_to_non_nullable
+              as int,
+      imageURL: null == imageURL
+          ? _value.imageURL
+          : imageURL // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MenuStateImpl implements _MenuState {
+  _$MenuStateImpl(
+      {required this.userId,
+      required this.name,
+      required this.date,
+      required this.timestamp,
+      required this.recipe,
+      required this.ingredient,
+      required this.calorie,
+      required this.imageURL});
+
+  @override
+  final String userId;
+  @override
+  final String name;
+  @override
+  final String date;
+  @override
+  final int timestamp;
+  @override
+  final String recipe;
+  @override
+  final String ingredient;
+  @override
+  final int calorie;
+  @override
+  final String imageURL;
+
+  @override
+  String toString() {
+    return 'MenuState(userId: $userId, name: $name, date: $date, timestamp: $timestamp, recipe: $recipe, ingredient: $ingredient, calorie: $calorie, imageURL: $imageURL)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MenuStateImpl &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.date, date) || other.date == date) &&
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp) &&
+            (identical(other.recipe, recipe) || other.recipe == recipe) &&
+            (identical(other.ingredient, ingredient) ||
+                other.ingredient == ingredient) &&
+            (identical(other.calorie, calorie) || other.calorie == calorie) &&
+            (identical(other.imageURL, imageURL) ||
+                other.imageURL == imageURL));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, userId, name, date, timestamp,
+      recipe, ingredient, calorie, imageURL);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MenuStateImplCopyWith<_$MenuStateImpl> get copyWith =>
+      __$$MenuStateImplCopyWithImpl<_$MenuStateImpl>(this, _$identity);
+}
+
+abstract class _MenuState implements MenuState {
+  factory _MenuState(
+      {required final String userId,
+      required final String name,
+      required final String date,
+      required final int timestamp,
+      required final String recipe,
+      required final String ingredient,
+      required final int calorie,
+      required final String imageURL}) = _$MenuStateImpl;
+
+  @override
+  String get userId;
+  @override
+  String get name;
+  @override
+  String get date;
+  @override
+  int get timestamp;
+  @override
+  String get recipe;
+  @override
+  String get ingredient;
+  @override
+  int get calorie;
+  @override
+  String get imageURL;
+  @override
+  @JsonKey(ignore: true)
+  _$$MenuStateImplCopyWith<_$MenuStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/project/bodquest_2023/lib/presentation/usecaese_provider_module.dart
+++ b/project/bodquest_2023/lib/presentation/usecaese_provider_module.dart
@@ -1,6 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../application/usecase/menu/add_menu_usecase_impl.dart';
+import '../application/usecase/menu/get_menus_usecase_impl.dart';
 import '../application/usecase/user/update_user_name_impl.dart';
+import '../domain/usecase/menu/add_menu_usecase.dart';
+import '../domain/usecase/menu/get_menus_usecase.dart';
 import '../domain/usecase/user/update_user_name_usecase.dart';
 import 'notifier/evaluation/evaluation_provider.dart';
 import 'repository_module.dart';
@@ -123,5 +127,20 @@ final calculateEvaluationUsecase = Provider<ICalculateEvaluationUsecase>(
     mealRepository: ref.watch(mealRepositoryProvider),
     getCaloriesConsumedUsecase: ref.watch(getCaloriesConsumedUsecaseProvider),
     evaluationNotifier: ref.watch(evaluationNotifierProvider.notifier),
+  ),
+);
+
+/// Menu
+///
+///
+final getMenusUsecaseProvider = Provider<IGetMenusUsecase>(
+  (ref) => GetMenusUsecaseImpl(
+    repository: ref.watch(menuRepositoryProvider),
+  ),
+);
+
+final addMenuUsecaseProvider = Provider<IAddMenuUsecase>(
+  (ref) => AddMenuUsecaseImpl(
+    repository: ref.watch(menuRepositoryProvider),
   ),
 );


### PR DESCRIPTION
* モデルの項目
レシピと材料が1項目ずつ持つのが理想が複雑になってしまいそうなので取り敢えず文字列で持つようにしています。
やはり個別に持ちたい場合は教えてください。
<img width="432" alt="image" src="https://github.com/SRKHD/procon2023/assets/150810307/08c91f6b-b826-4ac7-bb1e-751cd4803050">

* Firebase は以下のようになります。
* コレクションID：　menus
* ドキュメントID：　自動
* フィールド
　* userId : String
　* name: String
　* date: タイムスタンプ
　* recipe: String
　* ingredient: String
　* calorie: number
　* imageFilePath: String

一応imageFilePathも用意しました。
もし画像も保存する場合、Firebase Storageを使用するようです。
一応実装していますが、食事記録と同様に非同期での動作が怪しいかもです。
[食事記録モデル対応 #33](https://github.com/SRKHD/procon2023/pull/33)

<br/>
ViewではmenuListNotifierProviderを使用するだけでほぼ事足りると思います。

「weight_page.dart」を参考にしてみてください。