### PR TITLE
【アカウント作成画面】登録ボタンの見た目修正

### DIFF
--- a/project/bodquest_2023/lib/presentation/page/registration_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/registration_page.dart
@@ -28,7 +28,35 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
   Widget build(BuildContext context) {
     //登録ボタンの作成
     final resisterButton = ElevatedButton.icon(
-      onPressed: () {},
+      onPressed: () async {
+        if (_validPassword) {
+          try {
+            // メール/パスワードでユーザー登録
+            _result = await auth.createUserWithEmailAndPassword(
+              email: _email,
+              password: _password,
+            );
+
+            // 登録成功
+            // ホーム画面へ遷移
+            _user = _result.user!;
+            final notifier = ref.read(userListNotifierProvider.notifier);
+            notifier.addUser(_user.uid);
+            if (context.mounted) {
+              context.go('/main');
+            }
+          } on FirebaseAuthException catch (e) {
+            // 登録に失敗した場合
+            setState(() {
+              _infoText = AuthException(e.code).toString();
+            });
+          }
+        } else {
+          setState(() {
+            _infoText = 'パスワードは8文字以上です。';
+          });
+        }
+      },
       label: Text('登録'),
       icon: const Icon(Icons.add),
     );
@@ -84,39 +112,9 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
               minWidth: 350.0,
               // height: 100.0,
               child: ElevatedButton(
-                child:
-                    Text('登録', style: TextStyle(fontWeight: FontWeight.bold)),
-                onPressed: () async {
-                  if (_validPassword) {
-                    try {
-                      // メール/パスワードでユーザー登録
-                      _result = await auth.createUserWithEmailAndPassword(
-                        email: _email,
-                        password: _password,
-                      );
-
-                      // 登録成功
-                      // ホーム画面へ遷移
-                      _user = _result.user!;
-                      final notifier =
-                          ref.read(userListNotifierProvider.notifier);
-                      notifier.addUser(_user.uid);
-                      if (context.mounted) {
-                        context.go('/main');
-                      }
-                    } on FirebaseAuthException catch (e) {
-                      // 登録に失敗した場合
-                      setState(() {
-                        _infoText = AuthException(e.code).toString();
-                      });
-                    }
-                  } else {
-                    setState(() {
-                      _infoText = 'パスワードは8文字以上です。';
-                    });
-                  }
-                },
-              ),
+                  child:
+                      Text('登録', style: TextStyle(fontWeight: FontWeight.bold)),
+                  onPressed: () {}),
             ),
 
             Padding(

--- a/project/bodquest_2023/lib/presentation/page/registration_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/registration_page.dart
@@ -26,6 +26,13 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
 
   @override
   Widget build(BuildContext context) {
+    //登録ボタンの作成
+    final resisterButton = ElevatedButton.icon(
+      onPressed: () {},
+      label: Text('登録'),
+      icon: const Icon(Icons.add),
+    );
+
     return Scaffold(
       body: Center(
         child: Column(

--- a/project/bodquest_2023/lib/presentation/page/registration_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/registration_page.dart
@@ -109,13 +109,9 @@ class RegistrationPageState extends ConsumerState<RegistrationPage> {
             ),
 
             ButtonTheme(
-              minWidth: 350.0,
-              // height: 100.0,
-              child: ElevatedButton(
-                  child:
-                      Text('登録', style: TextStyle(fontWeight: FontWeight.bold)),
-                  onPressed: () {}),
-            ),
+                minWidth: 350.0,
+                // height: 100.0,
+                child: resisterButton),
 
             Padding(
               padding: EdgeInsets.fromLTRB(25.0, 25.0, 25.0, 0),


### PR DESCRIPTION
体重登録ページや、トレーニング登録ページの[登録ボタン]と、アカウント作成画面の[登録ボタン]の見た目が異なっていたので統一しました。（アカウント作成画面の[登録ボタン]をアイコン付きのボタンに変更しました。）

* 修正前
![image](https://github.com/SRKHD/procon2023/assets/150810307/f455013b-d836-4c91-ab44-d0bfc72d3963)

* 修正後
![image](https://github.com/SRKHD/procon2023/assets/150810307/df1d4a62-7695-4cec-9a4c-fb44f03755b4)