### PR TITLE
【食事/献立登録】プルダウンの選択によってUIを変更する・献立登録を選択していた場合の実装

### DIFF
--- a/project/bodquest_2023/lib/presentation/component/menu/menu_list_button.dart
+++ b/project/bodquest_2023/lib/presentation/component/menu/menu_list_button.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/colors.dart';
+import '../../theme/fonts.dart';
+import '../../theme/sizes.dart';
+import '../control/gap.dart';
+
+class MenuListButton extends StatelessWidget {
+  const MenuListButton({
+    super.key,
+    required this.onPressed,
+  });
+
+  /// コールバック
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    /// アイコン
+    const icon = Icon(Icons.list);
+
+    /// 文字
+    const text = Text(
+      '',
+      style: BrandText.bodyL,
+    );
+
+    /// レイアウト
+    return FloatingActionButton.extended(
+      heroTag: null,
+      backgroundColor: BrandColor.moriGreen,
+      onPressed: onPressed,
+      label: Row(
+        children: [
+          icon,
+          Gap.w(RawSize.p8),
+          text,
+        ],
+      ),
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/component/menu/menu_list_card.dart
+++ b/project/bodquest_2023/lib/presentation/component/menu/menu_list_card.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../control/editable_card.dart';
+
+class MenuListCard extends StatelessWidget {
+  const MenuListCard({
+    super.key,
+    required this.userId,
+    required this.id,
+    required this.recipe,
+    required this.onPressed,
+    required this.onPressedDelete,
+  });
+  final String userId;
+  final String id;
+  final String recipe;
+
+  /// コールバック カード選択
+  final Function(String, String) onPressed;
+
+  /// コールバック 削除
+  final Function(String, String) onPressedDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return EditableCard(
+      userId: userId,
+      id: id,
+      title: recipe,
+      subtitle: '',
+      imagePath: '',
+      onPressed: onPressed,
+      onPressedDelete: onPressedDelete,
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/component/menu/menu_listview.dart
+++ b/project/bodquest_2023/lib/presentation/component/menu/menu_listview.dart
@@ -1,0 +1,37 @@
+import 'package:bodquest_2023/presentation/state/menu/menu_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../state/menu/menu_state.dart';
+import 'menu_list_card.dart';
+
+class MenuListView extends ConsumerWidget {
+  const MenuListView({
+    super.key,
+    required this.menus,
+    required this.onPressed,
+    required this.onPressedDelete,
+  });
+
+  final List<MenuState> menus;
+
+  /// コールバック カード選択
+  final Function(String, String) onPressed;
+
+  /// コールバック 削除
+  final Function(String, String) onPressedDelete;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.builder(
+      itemCount: menus.length,
+      itemBuilder: (ctx, index) => MenuListCard(
+        userId: menus[index].userId,
+        id: menus[index].id,
+        recipe: menus[index].recipe,
+        onPressed: onPressed,
+        onPressedDelete: onPressedDelete,
+      ),
+    ); // return Expanded(
+  }
+}

--- a/project/bodquest_2023/lib/presentation/page/menu/menu_list_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/menu/menu_list_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../component/menu/menu_listview.dart';
+import '../../provider/menu/menu_list_provider.dart';
+import '../../router/go_router.dart';
+import '../../router/page_path.dart';
+import '../../theme/colors.dart';
+import '../../theme/l10n.dart';
+
+class MealListPage extends ConsumerWidget {
+  const MealListPage({super.key});
+
+  @override
+  Widget build(context, WidgetRef ref) {
+    final state = ref.watch(menuListNotifierProvider);
+    final notifier = ref.watch(menuListNotifierProvider.notifier);
+    return state.when(
+      data: (menus) {
+        //menus.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+        return Scaffold(
+          appBar: AppBar(
+            backgroundColor: BrandColor.moriGreen,
+            title: const Text(L10n.list),
+          ),
+          body: Column(
+            children: [
+              Expanded(
+                child: MenuListView(
+                  menus: menus,
+                  onPressed: (userId, id) {
+                    final router = ref.read(goRouterProvider);
+                    router.pushNamed(
+                      PageId.meal.routeName,
+                      pathParameters: {'id': id},
+                    );
+                  },
+                  onPressedDelete: (userId, id) => notifier.delete(userId, id),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+      error: (error, _) {
+        return Center(
+          child: Text(
+            error.toString(),
+          ),
+        );
+      },
+      loading: () {
+        return const Center(
+          child: CircularProgressIndicator(),
+        );
+      },
+    );
+  }
+}

--- a/project/bodquest_2023/lib/presentation/page/recipe_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/recipe_page.dart
@@ -27,6 +27,7 @@ class RecipePage extends ConsumerStatefulWidget {
 class RecipePageState extends ConsumerState<RecipePage> {
   final TextEditingController _controller = TextEditingController();
   final TextEditingController _calorieController = TextEditingController();
+  bool _isMeal = true;
 
   @override
   void dispose() {
@@ -39,6 +40,7 @@ class RecipePageState extends ConsumerState<RecipePage> {
   Widget build(BuildContext context) {
     final mealRegisterState =
         ref.watch(mealRegisterKindNotifierProvider(MealRegisterKind.meal));
+    _isMeal = mealRegisterState == MealRegisterKind.meal;
     final mealState = ref.watch(mealListNotifierProvider);
     final kindState = ref.watch(mealKindNotifierProvider(MealKind.breakfast));
     final logInUserState = ref.watch(logInUserNotifierProvider);
@@ -129,10 +131,19 @@ class RecipePageState extends ConsumerState<RecipePage> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 MealRegisterKindDropDown(mealRegisterState),
-                MealKindDropdown(kindState),
-                calenderComponents,
+                Visibility(
+                  child: MealKindDropdown(kindState),
+                  visible: _isMeal,
+                ),
+                Visibility(
+                  child: calenderComponents,
+                  visible: _isMeal,
+                ),
                 textComponents,
-                calorieTextComponents,
+                Visibility(
+                  child: calorieTextComponents,
+                  visible: _isMeal,
+                ),
                 resisterButton,
               ],
             ),

--- a/project/bodquest_2023/lib/presentation/page/recipe_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/recipe_page.dart
@@ -28,6 +28,7 @@ class RecipePageState extends ConsumerState<RecipePage> {
   final TextEditingController _controller = TextEditingController();
   final TextEditingController _calorieController = TextEditingController();
   bool _isMeal = true;
+  String _label = "";
 
   @override
   void dispose() {
@@ -49,9 +50,10 @@ class RecipePageState extends ConsumerState<RecipePage> {
     print(logInUserState.userName);
     final dateState = ref.watch(dateTimeNotifierProvider(widget.initDate));
 
+    _label = _isMeal ? "食事" : "献立";
     final textField = TextFormField(
       controller: _controller,
-      decoration: InputDecoration(labelText: "食事"),
+      decoration: InputDecoration(labelText: _label),
     );
 
     final textComponents = SizedBox(

--- a/project/bodquest_2023/lib/presentation/page/recipe_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/recipe_page.dart
@@ -105,13 +105,16 @@ class RecipePageState extends ConsumerState<RecipePage> {
 
     final resisterButton = ElevatedButton.icon(
       onPressed: () {
-        final notifier = ref.read(mealListNotifierProvider.notifier);
-        var calorie =
-            _calorieController.text == '' ? '-1' : _calorieController.text;
-        notifier.add(logInUserState.userId, kindState.name, _controller.text,
-            dateState, int.parse(calorie), '');
-        _controller.text = '';
-        _calorieController.text = '';
+        if (_isMeal) {
+          final mealNotifier = ref.read(mealListNotifierProvider.notifier);
+          var calorie =
+              _calorieController.text == '' ? '-1' : _calorieController.text;
+          mealNotifier.add(logInUserState.userId, kindState.name,
+              _controller.text, dateState, int.parse(calorie), '');
+          _controller.text = '';
+          _calorieController.text = '';
+        } else {
+        }
       },
       label: Text('登録'),
       icon: const Icon(Icons.add),

--- a/project/bodquest_2023/lib/presentation/page/recipe_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/recipe_page.dart
@@ -114,6 +114,10 @@ class RecipePageState extends ConsumerState<RecipePage> {
           _controller.text = '';
           _calorieController.text = '';
         } else {
+          final recipeNotifier = ref.read(menuListNotifierProvider.notifier);
+          recipeNotifier.add(logInUserState.userId, '', dateState,
+              _controller.text, '', -1, '');
+          _controller.text = '';
         }
       },
       label: Text('登録'),

--- a/project/bodquest_2023/lib/presentation/page/recipe_page.dart
+++ b/project/bodquest_2023/lib/presentation/page/recipe_page.dart
@@ -6,11 +6,13 @@ import '../component/component_types.dart';
 import '../component/control/number_textfield.dart';
 import '../component/meal/meal_kind_dropdown.dart';
 import '../component/meal/meal_list_button.dart';
+import '../component/menu/menu_list_button.dart';
 import '../notifier/datetime_notifier.dart';
 import '../notifier/meal/mealRegister_kind_notifier.dart';
 import '../notifier/meal/meal_kind_notifier.dart';
 import '../notifier/text_notifier.dart';
 import '../provider/meal/meal_list_provider.dart';
+import '../provider/menu/menu_list_provider.dart';
 import '../provider/user/login_user_provider.dart';
 import '../router/go_router.dart';
 import '../router/page_path.dart';
@@ -124,13 +126,21 @@ class RecipePageState extends ConsumerState<RecipePage> {
       icon: const Icon(Icons.add),
     );
 
-    final listButton = MealListButton(onPressed: () {
+    final mealListButton = MealListButton(onPressed: () {
       final router = ref.read(goRouterProvider);
       router.pushNamed(
         PageId.meallist.routeName,
       );
     });
 
+    final recipeListButton = MenuListButton(onPressed: () {
+      final router = ref.read(goRouterProvider);
+      router.pushNamed(
+        PageId.recipelist.routeName,
+      );
+    });
+
+    final listButton = _isMeal ? mealListButton : recipeListButton;
     return mealState.when(
       data: (meals) {
         return Scaffold(

--- a/project/bodquest_2023/lib/presentation/router/page_path.dart
+++ b/project/bodquest_2023/lib/presentation/router/page_path.dart
@@ -9,6 +9,7 @@ enum PageId {
   trainingedit,
   meal,
   meallist,
+  recipelist,
 }
 
 /// 画面パス
@@ -23,6 +24,7 @@ extension PagePath on PageId {
         PageId.trainingedit => '/training/edit/:id',
         PageId.meal => '/meal',
         PageId.meallist => '/meal/meallist',
+        PageId.recipelist => '/meal/recipelist',
       };
 }
 
@@ -38,5 +40,6 @@ extension PageName on PageId {
         PageId.trainingedit => 'trainingedit',
         PageId.meal => 'meal',
         PageId.meallist => 'meallist',
+        PageId.recipelist => 'recipelist',
       };
 }


### PR DESCRIPTION
プルダウンの選択によってUIを変更できるよう実装しました。
* 初回表示：食事登録
![image](https://github.com/SRKHD/procon2023/assets/150810307/01d2aba7-c815-4343-9771-282483ec8198)

* 献立登録のUI
![image](https://github.com/SRKHD/procon2023/assets/150810307/e391768d-62cd-4f5c-8a27-3f5bc5b7721b)

また、献立登録画面で、献立名を入力して登録を押したとき、DB側に登録されるよう実装しました。

【不具合】
※プルダウンで献立登録→食事登録に変更する時、一回で変わらない（2回押す必要がある）
※献立登録画面でリストボタンを押しても表示されない